### PR TITLE
Validate qr

### DIFF
--- a/components/screens/QRScannerScreen.js
+++ b/components/screens/QRScannerScreen.js
@@ -33,10 +33,37 @@ export default class QRScannerScreen extends React.Component {
         );
     }
 
+    parseAndValidateJSON = (str) => {
+        //check for null input
+        if (!(!!str)) return false;
+        //check that input is a string
+        if( typeof( str ) !== 'string' ) return false; 
+
+        let json;
+        try {
+            json = JSON.parse(str)
+        } catch (e) {
+            return false;
+        }
+        //once parsed, check that it is NOT an array
+        if( json instanceof Array ){
+            console.log("array");
+            return false;
+        } 
+
+        return json;
+    }
+
     handleBarCodeScanned = ({ type, data }) => {
         //alert(`Bar code with type ${type} and data is ${typeof data} `);
-        data = JSON.parse(data);
-        if(data.screen) {
+        data = this.parseAndValidateJSON(data);
+        if(!data || !data.promisorID) {
+            this.props.navigation.navigate('Home');
+            
+        } else if(!data.terms) {
+            alert("cannot accept a promise with empty terms");
+            this.props.navigation.navigate('Home');
+        } else if(data.screen) {
             this.props.navigation.navigate('ResolveReview', data);
         } else {
             this.props.navigation.navigate('Review', data);

--- a/components/screens/QRScannerScreen.js
+++ b/components/screens/QRScannerScreen.js
@@ -69,7 +69,7 @@ export default class QRScannerScreen extends React.Component {
             title = 'Error!';
             message = 'Invalid QR Code'
             btn1Text = 'Scan again',
-            btn2Text = 'cancel'
+            btn2Text = 'Cancel'
             btn1PressAction = () => this.setState({scanned: false});
         } else if(!data.terms) { //if the data is valid, but there are no promise terms specified
             title = 'Alert!'

--- a/components/screens/QRScannerScreen.js
+++ b/components/screens/QRScannerScreen.js
@@ -1,12 +1,13 @@
 import React from 'react';
-import { StyleSheet, Text, View } from 'react-native';
-import { BarCodeScanner, Permissions } from 'expo';
+import { StyleSheet, Text, View, Button, Alert } from 'react-native';
+import { BarCodeScanner, Permissions, Constants } from 'expo';
 import { Auth } from 'aws-amplify'
 
 
 export default class QRScannerScreen extends React.Component {
     state = {
         hasCameraPermission: null,
+        scanned: false
     }
 
     async componentDidMount() {
@@ -15,19 +16,19 @@ export default class QRScannerScreen extends React.Component {
     }
 
     render() {
-        const { hasCameraPermission } = this.state;
+        const { hasCameraPermission, scanned } = this.state;
 
         if (hasCameraPermission === null) {
-            return <Text>Requesting for camera permission</Text>;
+            return <Text>Requesting camera permission</Text>;
         }
         if (hasCameraPermission === false) {
             return <Text>No access to camera</Text>;
         }
         return (
-            <View style={{ flex: 1 }}>
+            <View style={{ flex: 1, justifyContent: 'flex-end' }}>
                 <BarCodeScanner
-                    onBarCodeScanned={this.handleBarCodeScanned}
-                    style={StyleSheet.absoluteFill}
+                    onBarCodeScanned={ scanned ? undefined : this.handleBarCodeScanned}
+                    style={StyleSheet.absoluteFillObject}
                 />
             </View>
         );
@@ -55,18 +56,56 @@ export default class QRScannerScreen extends React.Component {
     }
 
     handleBarCodeScanned = ({ type, data }) => {
-        //alert(`Bar code with type ${type} and data is ${typeof data} `);
+        //alert variables
+        let title, message, btn1Text, btn2Text, btn1PressAction;
+        
+        //set scanned to 'true' to stop continuous scanning
+        this.setState({ scanned: true });
+
+        //parse scanned data to make sure its valid JSON
         data = this.parseAndValidateJSON(data);
-        if(!data || !data.promisorID) {
-            this.props.navigation.navigate('Home');
-            
-        } else if(!data.terms) {
-            alert("cannot accept a promise with empty terms");
-            this.props.navigation.navigate('Home');
-        } else if(data.screen) {
-            this.props.navigation.navigate('ResolveReview', data);
+
+        if(!data || !data.promisorID) {  //if data is invalid, or is not a promise object
+            title = 'Error!';
+            message = 'Invalid QR Code'
+            btn1Text = 'Scan again',
+            btn2Text = 'cancel'
+            btn1PressAction = () => this.setState({scanned: false});
+        } else if(!data.terms) { //if the data is valid, but there are no promise terms specified
+            title = 'Alert!'
+            message = 'Pledge terms are blank -- cannot be accepted';
+            btn1Text = 'Scan again',
+            btn2Text = 'cancel',
+            btn1PressAction = () => this.setState({scanned: false});
+        } else if(data.screen) { //if the 'screen' attribute is present, this is a pledge submitted for resolution
+            title = 'Resolve?'
+            message = `${data.promisorFirstName} claims to have resolved a pledge.`
+            btn1Text = 'Review';
+            btn2Text = 'Dismiss';
+            btn1PressAction = () => this.props.navigation.navigate('ResolveReview', data);
         } else {
-            this.props.navigation.navigate('Review', data);
+            title = 'Plege Received'
+            message = `${data.promisorFirstName} has made a pledge.`
+            btn1Text = 'Review terms';
+            btn2Text = 'Dismiss';
+            btn1PressAction = () => this.props.navigation.navigate('Review', data);
         }
+
+        Alert.alert(
+            title,
+            message,
+            [
+              {
+                text: btn1Text, 
+                onPress: () => btn1PressAction()
+              },
+              {
+                text: btn2Text,
+                onPress: () => this.props.navigation.navigate('Home'),
+                style: 'cancel',
+              }
+            ],
+            {cancelable: false},
+          );
     }
 }


### PR DESCRIPTION
Validate QR code and display custom alert based on scanned data.  Stop scanning after first successful scan. Canceling alert re-enables scanning or re-directs home, as appropriate.  Other navigation is handled via the onPress property of the affirmative button in the alert.  