### PR TITLE
Pledge tab default appearance

### DIFF
--- a/components/screens/PledgesMadeScreen.js
+++ b/components/screens/PledgesMadeScreen.js
@@ -5,8 +5,7 @@ import {
   View,
   FlatList,
   ActivityIndicator,
-  TouchableOpacity, 
-  Button
+  TouchableOpacity
 } from 'react-native';
 import { Auth } from 'aws-amplify';
 import { getData } from '../../utilities/services'
@@ -71,22 +70,6 @@ export default class PledgesMadeScreen extends React.Component {
           <ActivityIndicator size="large"></ActivityIndicator>
         </View>
       )
-    } else if (this.state.pledgesMade.length === 0) {
-      return (
-        <View style={{flex: 1}}>
-          <View style={{flex: 1, justifyContent: "center"}}>
-            <Text style={{ fontSize: 16, textAlign: 'center' }}>You have not made any pledges.</Text>
-          </View>
-
-          <View style={{flex: 4, alignItems: "center"}}>
-              <TouchableOpacity
-                style={styles.button}
-                onPress={ () => this.onRefresh() }>
-                <Text style={styles.buttonText}>Refresh</Text>
-              </TouchableOpacity>
-            </View>
-        </View>
-      )
     } else {
       return (
         <View style={styles.container}>
@@ -95,7 +78,12 @@ export default class PledgesMadeScreen extends React.Component {
             keyExtractor={(x, i) => i.toString()}
             onRefresh={() => this.onRefresh()}
             refreshing={this.state.isFetching}
-
+            ListEmptyComponent={
+              <View style={{ flex: 1, justifyContent: "center", paddingTop: 25 }}>
+                <Text style={{ fontSize: 16, textAlign: 'center' }}>You have not made any pledges.</Text>
+                <Text style={{ fontSize: 14, textAlign: 'center', paddingTop: 10 }}>(Pull to refresh)</Text>
+              </View>
+            }
             renderItem={({ item }) => (
               <View>
                 <TouchableOpacity
@@ -107,7 +95,6 @@ export default class PledgesMadeScreen extends React.Component {
 
                 </TouchableOpacity>
               </View>
-
             )}
           />
         </View>

--- a/components/screens/PledgesMadeScreen.js
+++ b/components/screens/PledgesMadeScreen.js
@@ -5,7 +5,8 @@ import {
   View,
   FlatList,
   ActivityIndicator,
-  TouchableOpacity
+  TouchableOpacity, 
+  Button
 } from 'react-native';
 import { Auth } from 'aws-amplify';
 import { getData } from '../../utilities/services'
@@ -72,8 +73,18 @@ export default class PledgesMadeScreen extends React.Component {
       )
     } else if (this.state.pledgesMade.length === 0) {
       return (
-        <View style={styles.contaienr}>
-          <Text style={{ fontSize: 16, textAlign: 'center', marginTop: 20 }}>You have not made any pledges.</Text>
+        <View style={{flex: 1}}>
+          <View style={{flex: 1, justifyContent: "center"}}>
+            <Text style={{ fontSize: 16, textAlign: 'center' }}>You have not made any pledges.</Text>
+          </View>
+
+          <View style={{flex: 4, alignItems: "center"}}>
+              <TouchableOpacity
+                style={styles.button}
+                onPress={ () => this.onRefresh() }>
+                <Text style={styles.buttonText}>Refresh</Text>
+              </TouchableOpacity>
+            </View>
         </View>
       )
     } else {
@@ -113,5 +124,17 @@ const styles = StyleSheet.create({
   },
   container: {
     flex: 1,
-  }
+  },
+  button: {
+    alignItems: 'center',
+    justifyContent: "center",
+    backgroundColor: '#DDDDDD',
+    padding: 10,
+    height: "10%",
+    width: "25%",
+    borderRadius: 10
+  },
+  buttonText: {
+    fontWeight: "bold"
+  },
 });

--- a/components/screens/PledgesMadeScreen.js
+++ b/components/screens/PledgesMadeScreen.js
@@ -8,28 +8,26 @@ import {
   TouchableOpacity
 } from 'react-native';
 import { Auth } from 'aws-amplify';
-import { Card } from 'react-native-elements';
 import { getData } from '../../utilities/services'
 
 import PledgeCard from '../screenComponents/PledgeCard'
 
-
 export default class PledgesMadeScreen extends React.Component {
 
   state = {
-    pledgesMade: null, 
+    pledgesMade: null,
     isFetching: false
   }
 
   static navigationOptions = {
-    title: 'Pledges I Made',
+    title: "Pledges I've Made",
   };
 
   async componentDidMount() {
     console.log("I AM MOUNTING THE MADE SCREEN!")
     let userInfo = await this.getId();
     let promisorId = userInfo.userID;
-    this.setState({isFetching: true});
+    this.setState({ isFetching: true });
     const apiData = await getData(promisorId, "index");
     this.setState({
       promisorId: promisorId,
@@ -46,16 +44,9 @@ export default class PledgesMadeScreen extends React.Component {
     console.log(newPledges)
     this.setState({
       pledgesMade: newPledges,
-      isFetching: false})
- }
-
-  // getData = async (promisorId) => {
-  //   console.log("getting data from api...")
-  //   let apiName = 'PledgesCRUD';
-  //   let path = `/pledges/${promisorId}?message=index`;
-  //   let apiData = await API.get(apiName, path);
-  //   return apiData;
-  // }
+      isFetching: false
+    })
+  }
 
   getId = async () => {
     try {
@@ -63,8 +54,7 @@ export default class PledgesMadeScreen extends React.Component {
       let user = await Auth.currentAuthenticatedUser()
       userInfo.userID = await user.attributes.sub;
       userInfo.firstName = await user.attributes.name;
-      userInfo.lastName = await user.attributes.family_name;
-      //console.log(user);
+      userInfo.lastName = await user.attributes.family_name;;
       return userInfo;
     } catch (error) {
       console.log(error);
@@ -72,49 +62,53 @@ export default class PledgesMadeScreen extends React.Component {
   }
 
   render() {
-    console.log("YO! THE STATE IS:")
-    console.log(this.state.pledgesMade);
-    return (
-      <View style={styles.container}>
-        {
-          !this.state.pledgesMade ? (
-            <View style={styles.indicatorContainer}>
-            <ActivityIndicator size="large"></ActivityIndicator>
-            </View>
-          ) : (
-            
-              <FlatList
-                data={this.state.pledgesMade}
-                keyExtractor={(x, i) => i.toString()}
-                onRefresh={() => this.onRefresh()}
-                refreshing={this.state.isFetching}
+    //console.log("YO! THE STATE IS:")
+    //console.log(this.state.pledgesMade);
+    if (!this.state.pledgesMade || this.state.isFetching) {
+      return (
+        <View style={styles.indicatorContainer}>
+          <ActivityIndicator size="large"></ActivityIndicator>
+        </View>
+      )
+    } else if (this.state.pledgesMade.length === 0) {
+      return (
+        <View style={styles.contaienr}>
+          <Text style={{ fontSize: 16, textAlign: 'center', marginTop: 20 }}>You have not made any pledges.</Text>
+        </View>
+      )
+    } else {
+      return (
+        <View style={styles.container}>
+          <FlatList
+            data={this.state.pledgesMade}
+            keyExtractor={(x, i) => i.toString()}
+            onRefresh={() => this.onRefresh()}
+            refreshing={this.state.isFetching}
 
-                renderItem={({ item }) => (
-                  <View>
-                    <TouchableOpacity
-                      onPress={() => this.props.navigation.navigate('Details', {...item, screen: 'made'})}
-                    >
-                    <PledgeCard 
-                    pledge={item} 
+            renderItem={({ item }) => (
+              <View>
+                <TouchableOpacity
+                  onPress={() => this.props.navigation.navigate('Details', { ...item, screen: 'made' })}
+                >
+                  <PledgeCard
+                    pledge={item}
                     screen={this.props.navigation.state.routeName} />
 
-                    </TouchableOpacity>
-                  </View>
+                </TouchableOpacity>
+              </View>
 
-                )}
-              />
-            )
-        }
-
-      </View>
-    );
+            )}
+          />
+        </View>
+      )
+    }
   }
 }
 
 const styles = StyleSheet.create({
   indicatorContainer: {
     flex: 1,
-    justifyContent: "center", 
+    justifyContent: "center",
     alignItems: "center"
   },
   container: {

--- a/components/screens/PledgesOwedScreen.js
+++ b/components/screens/PledgesOwedScreen.js
@@ -71,22 +71,6 @@ export default class PledgesOwedScreen extends React.Component {
           <ActivityIndicator size="large"></ActivityIndicator>
         </View>
       )
-    } else if (this.state.pledgesOwed.length === 0) {
-      return (
-        <View style={{flex: 1}}>
-          <View style={{flex: 1, justifyContent: "center"}}>
-            <Text style={{ fontSize: 16, textAlign: 'center' }}>You have no pledges owed to you.</Text>
-          </View>
-
-          <View style={{flex: 4, alignItems: "center"}}>
-              <TouchableOpacity
-                style={styles.button}
-                onPress={ () => this.onRefresh() }>
-                <Text style={styles.buttonText}>Refresh</Text>
-              </TouchableOpacity>
-            </View>
-        </View>
-      )
     } else {
       return (
         <View style={styles.container}>
@@ -95,7 +79,12 @@ export default class PledgesOwedScreen extends React.Component {
             keyExtractor={(x, i) => i.toString()}
             onRefresh={() => this.onRefresh()}
             refreshing={this.state.isFetching}
-
+            ListEmptyComponent={
+              <View style={{ flex: 1, justifyContent: "center", paddingTop: 25 }}>
+                <Text style={{ fontSize: 16, textAlign: 'center' }}>You have no pledges owed to you.</Text>
+                <Text style={{ fontSize: 14, textAlign: 'center', paddingTop: 10 }}>(Pull to refresh)</Text>
+              </View>
+            }
             renderItem={({ item }) => (
               <View>
                 <TouchableOpacity
@@ -107,7 +96,6 @@ export default class PledgesOwedScreen extends React.Component {
 
                 </TouchableOpacity>
               </View>
-
             )}
           />
         </View>

--- a/components/screens/PledgesOwedScreen.js
+++ b/components/screens/PledgesOwedScreen.js
@@ -8,16 +8,14 @@ import {
   TouchableOpacity
 } from 'react-native';
 import { Auth } from 'aws-amplify';
-import { Card } from 'react-native-elements';
 import { getData } from '../../utilities/services';
 
 import PledgeCard from '../screenComponents/PledgeCard'
 
-
 export default class PledgesOwedScreen extends React.Component {
 
   state = {
-    pledgesOwed: null, 
+    pledgesOwed: null,
     isFetching: false
   }
 
@@ -29,7 +27,7 @@ export default class PledgesOwedScreen extends React.Component {
     console.log("I AM MOUNTING THE OWED SCREEN!")
     let userInfo = await this.getId();
     let promiseeId = userInfo.userID;
-    this.setState({isFetching: true});
+    this.setState({ isFetching: true });
     const apiData = await getData(promiseeId, null);
     this.setState({
       promiseeId: promiseeId,
@@ -46,12 +44,12 @@ export default class PledgesOwedScreen extends React.Component {
     console.log(newPledges)
     this.setState({
       pledgesOwed: newPledges,
-      isFetching: false})
- }
+      isFetching: false
+    })
+  }
 
-
-getId = async () => {
-  try {
+  getId = async () => {
+    try {
       let userInfo = {};
       let user = await Auth.currentAuthenticatedUser()
       userInfo.userID = await user.attributes.sub;
@@ -59,43 +57,62 @@ getId = async () => {
       userInfo.lastName = await user.attributes.family_name;
       //console.log(user);
       return userInfo;
-  } catch (error) {
+    } catch (error) {
       console.log(error);
+    }
   }
-}
 
   render() {
+    // console.log("YO! THE STATE IS:")
+    // console.log(this.state.pledgesOwed);
+    if (!this.state.pledgesOwed || this.state.isFetching) {
+      return (
+        <View style={styles.indicatorContainer}>
+          <ActivityIndicator size="large"></ActivityIndicator>
+        </View>
+      )
+    } else if (this.state.pledgesOwed.length === 0) {
+      return (
+        <View style={styles.contaienr}>
+          <Text style={{ fontSize: 16, textAlign: 'center', marginTop: 20 }}>You do not have any pledges owed to you.</Text>
+        </View>
+      )
+    } else {
+      return (
+        <View style={styles.container}>
+          <FlatList
+            data={this.state.pledgesOwed}
+            keyExtractor={(x, i) => i.toString()}
+            onRefresh={() => this.onRefresh()}
+            refreshing={this.state.isFetching}
 
-    return (
-      <View style={styles.container}>
-        {
-          !this.state.pledgesOwed ? (
-            <ActivityIndicator></ActivityIndicator>
-          ) : (
-            <FlatList 
-              data={this.state.pledgesOwed}
-              keyExtractor={(x, i) => i.toString()}
-              onRefresh={() => this.onRefresh()}
-              refreshing={this.state.isFetching}
-              renderItem={({ item }) => (
+            renderItem={({ item }) => (
+              <View>
                 <TouchableOpacity
-                      onPress={() => this.props.navigation.navigate('Details', {...item, screen: 'owed'})}
-                    >
-                    <PledgeCard pledge={item} />
+                  onPress={() => this.props.navigation.navigate('Details', { ...item, screen: 'owed' })}
+                >
+                  <PledgeCard
+                    pledge={item}
+                    screen={this.props.navigation.state.routeName} />
 
-                    </TouchableOpacity>
-              
-              )}
-            />
-          )
-        }
-        
-      </View>
-    );
+                </TouchableOpacity>
+              </View>
+
+            )}
+          />
+        </View>
+      )
+    }
   }
+
 }
 
 const styles = StyleSheet.create({
+  indicatorContainer: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center"
+  },
   container: {
     flex: 1,
   }

--- a/components/screens/PledgesOwedScreen.js
+++ b/components/screens/PledgesOwedScreen.js
@@ -73,8 +73,18 @@ export default class PledgesOwedScreen extends React.Component {
       )
     } else if (this.state.pledgesOwed.length === 0) {
       return (
-        <View style={styles.contaienr}>
-          <Text style={{ fontSize: 16, textAlign: 'center', marginTop: 20 }}>You do not have any pledges owed to you.</Text>
+        <View style={{flex: 1}}>
+          <View style={{flex: 1, justifyContent: "center"}}>
+            <Text style={{ fontSize: 16, textAlign: 'center' }}>You have no pledges owed to you.</Text>
+          </View>
+
+          <View style={{flex: 4, alignItems: "center"}}>
+              <TouchableOpacity
+                style={styles.button}
+                onPress={ () => this.onRefresh() }>
+                <Text style={styles.buttonText}>Refresh</Text>
+              </TouchableOpacity>
+            </View>
         </View>
       )
     } else {
@@ -115,5 +125,17 @@ const styles = StyleSheet.create({
   },
   container: {
     flex: 1,
-  }
+  },
+  button: {
+    alignItems: 'center',
+    justifyContent: "center",
+    backgroundColor: '#DDDDDD',
+    padding: 10,
+    height: "10%",
+    width: "25%",
+    borderRadius: 10
+  },
+  buttonText: {
+    fontWeight: "bold"
+  },
 });


### PR DESCRIPTION
It works.  Shows default message and pull-to-refresh still works, so the screen can be refreshed if a newly created or received pledge does not appear right away.  Could probably be improved so that the refresh indicator is not abruptly replaced by the centered activity indicator, but it's good enough for now.  Tested on both iOS and Android